### PR TITLE
Opening up Lambda Policy for Step Functions as they require it...

### DIFF
--- a/step_function.tf
+++ b/step_function.tf
@@ -58,14 +58,14 @@ resource "aws_iam_policy" "policy_invoke_lambda" {
             "Sid": "VisualEditor0",
             "Effect": "Allow",
             "Action": [
-                "lambda:InvokeFunction",
-                "lambda:InvokeAsync"
+                "lambda:*"
             ],
             "Resource": [
                 "${module.pdf_to_text.lambda_function_arn}",
                 "${module.typedb_search_query.lambda_function_arn}",
                 "${module.keyword_extraction.lambda_function_arn}",
-                "${module.typedb_ingestion.lambda_function_arn}"
+                "${module.typedb_ingestion.lambda_function_arn}",
+                "arn:aws:lambda:eu-west-2:*:*"
             ]
         }
     ]


### PR DESCRIPTION
Not super happy about opening up SF permissions in this way, but after looking at it there doesn't appear to be another way to achieve Lambda invoking with Step Functions - we previously had a full Identity-based Policy that allowed the Lambdas specifically, but it didn't work at all.