### PR TITLE
Fixing TTL for DDB

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -8,11 +8,6 @@ resource "aws_dynamodb_table" "legislative-origin" {
     type = "S"
   }
 
-  ttl {
-    attribute_name = "TimeToExist"
-    enabled        = false
-  }
-
   tags = {
     Name        = "legislative-origin"
     Environment = local.environment


### PR DESCRIPTION
Code was trying to set TTL to false, is already set to true by default in AWS so this must be set to true. Apparently this is a known issue in this TF.